### PR TITLE
Unify model_attribute: false behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ model attributes name) and
 4. [Map Form Object to Models](4-map-form-objects-to-models)
    1. [Multiple Models Example](41-multiple-models-example)
    2. [Skip Attribute Mapping](42-skip-attribute-mapping)
-      1. [Map Nested Form Object Attribute to Parent Level Model Attribute](421-map-nested-form-object-attribute-to-parent-level-model-attribute)
-   3. [Map Nested Form Object to A Hash Model](43-map-nested-form-object-to-a-hash-model)
+   3. [Map Nested Form Object Attribute to Parent Level Model Attribute](43-map-nested-form-object-attribute-to-parent-level-model-attribute)
+   4. [Map Nested Form Object to A Hash Model](44-map-nested-form-object-to-a-hash-model)
 5. [Load Form Object from Models](5-load-form-object-from-models)
 6. [Save Form Object to Models](6-save-form-object-to-models)
    1. [Array of Form Objects and Models](61-array-of-form-objects-and-models)
@@ -500,10 +500,9 @@ Suppose `form = SimpleForm.new` and `model` to be an instance of a model.
 | `form.year` | `model.year` |
 | `form.engine_power` | - |
 
-##### 4.2.1. Map Nested Form Object Attribute to Parent Level Model Attribute
+#### 4.3. Map Nested Form Object Attribute to Parent Level Model Attribute
 
-TODO: replace `model_attribute` by `model`
-Use `model_attribute: false` for nested form object in order to map its attributes to the parent level of the model.
+Use `model_nesting: false` for nested form object in order to map its attributes to the parent level of the model.
 
 ```ruby
 class NestedForm < FormObj::Form
@@ -511,7 +510,7 @@ class NestedForm < FormObj::Form
     
   attribute :name, model_attribute: :team_name
   attribute :year
-  attribute :car, model_attribute: false do   # nesting only in form object but not in a model
+  attribute :car, model_nesting: false do   # nesting only in form object but not in a model
     attribute :code
     attribute :driver
     attribute :engine do
@@ -533,7 +532,7 @@ Suppose `form = NestedForm.new` and `model` to be an instance of a model.
 | `form.car.engine.power` | `model.engine.power` |
 | `form.car.engine.volume` | `model.engine.volume` |
 
-#### 4.3. Map Nested Form Object to A Hash Model
+#### 4.4. Map Nested Form Object to A Hash Model
 
 Use `model_hash: true` in order to map a nested form object to a hash as a model.
 

--- a/lib/form_obj/model_mapper/attribute.rb
+++ b/lib/form_obj/model_mapper/attribute.rb
@@ -5,8 +5,8 @@ module FormObj
     class Attribute < FormObj::Form::Attribute
       attr_reader :model_attribute
 
-      def initialize(name, array: false, class: nil, default: nil, model_hash: false, model: :default, model_attribute: nil, model_class: nil, parent:, primary_key: nil, &block)
-        @model_attribute = ModelAttribute.new(model: model, names: model_attribute, classes: model_class, default_name: name, array: array, hash: model_hash, subform: binding.local_variable_get(:class) || block_given?)
+      def initialize(name, array: false, class: nil, default: nil, model_hash: false, model: :default, model_attribute: nil, model_class: nil, model_nesting: true, parent:, primary_key: nil, &block)
+        @model_attribute = ModelAttribute.new(model: model, names: model_attribute, classes: model_class, default_name: name, nesting: model_nesting, array: array, hash: model_hash, subform: binding.local_variable_get(:class) || block_given?)
 
         if block_given?
           new_block = Proc.new do

--- a/lib/form_obj/model_mapper/model_attribute.rb
+++ b/lib/form_obj/model_mapper/model_attribute.rb
@@ -6,9 +6,10 @@ module FormObj
     class ModelAttribute
       attr_reader :model
 
-      def initialize(names:, classes:, default_name:, array:, hash:, subform:, model:)
+      def initialize(names:, classes:, default_name:, array:, hash:, subform:, model:, nesting:)
         @read_from_model = @write_to_model = !(names === false)
 
+        @nesting = nesting
         @model = model
         @array = array
 
@@ -40,6 +41,10 @@ module FormObj
       def create_model
         raise 'Creation available only for array attributes' unless @array
         @items.last.create_model
+      end
+
+      def nesting?
+        @nesting
       end
 
       def read_from_model?

--- a/spec/model_mapper/load_from_models/array_of_forms_few_models_empty_spec.rb
+++ b/spec/model_mapper/load_from_models/array_of_forms_few_models_empty_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'load_from_models: Array of Form Objects - Few Empty Models' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false do
+        attribute :colours, array: true, model_nesting: false do
           attribute :name
           attribute :rgb
         end
@@ -137,7 +137,7 @@ RSpec.describe 'load_from_models: Array of Form Objects - Few Empty Models' do
           attribute :cars, array: true, class: CarForm
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm
           attribute :chassis, array: true, model_hash: true, class: ChassisForm, model: :chassis
-          attribute :colours, array: true, model_attribute: false, class: ColourForm
+          attribute :colours, array: true, model_nesting: false, class: ColourForm
         end
       end
     end

--- a/spec/model_mapper/load_from_models/array_of_forms_few_models_spec.rb
+++ b/spec/model_mapper/load_from_models/array_of_forms_few_models_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'load_from_models: Array of Form Objects - Few Models' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false do
+        attribute :colours, array: true, model_nesting: false do
           attribute :name
           attribute :rgb
         end
@@ -178,7 +178,7 @@ RSpec.describe 'load_from_models: Array of Form Objects - Few Models' do
           attribute :cars, array: true, class: CarForm
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm
           attribute :chassis, array: true, model_hash: true, class: ChassisForm, model: :chassis
-          attribute :colours, array: true, model_attribute: false, class: ColourForm
+          attribute :colours, array: true, model_nesting: false, class: ColourForm
         end
       end
     end

--- a/spec/model_mapper/load_from_models/array_of_forms_one_model_empty_spec.rb
+++ b/spec/model_mapper/load_from_models/array_of_forms_one_model_empty_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Empty Model' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false do
+        attribute :colours, array: true, model_nesting: false do
           attribute :name
           attribute :rgb
         end
@@ -134,7 +134,7 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Empty Model' do
           attribute :cars, array: true, class: CarForm
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm
           attribute :chassis, array: true, model_hash: true, class: ChassisForm
-          attribute :colours, array: true, model_attribute: false, class: ColourForm
+          attribute :colours, array: true, model_nesting: false, class: ColourForm
         end
       end
     end

--- a/spec/model_mapper/load_from_models/array_of_forms_one_model_spec.rb
+++ b/spec/model_mapper/load_from_models/array_of_forms_one_model_spec.rb
@@ -17,10 +17,16 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Model' do
 
   let(:colour) { Struct.new(:name, :rgb) }
 
+  let(:drivers_championship) { Struct.new(:driver, :year) }
+  let(:drivers_championships) {[
+      drivers_championship.new('Ascari', 1952),
+      drivers_championship.new('Hawthorn', 1958)
+  ]}
+
   module LoadFromModel
     class ArrayForm < FormObj::Form
       class Model < ::Array
-        attr_accessor :team_name, :year, :cars, :finance, :chassis
+        attr_accessor :team_name, :year, :cars, :finance, :chassis, :drivers_championships
       end
     end
   end
@@ -32,6 +38,7 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Model' do
     model.cars = cars
     model.finance = finance
     model.chassis = chassis
+    model.drivers_championships = drivers_championships
 
     model.push(colour.new('red', 0xFF0000), colour.new('green', 0x00FF00), colour.new('blue', 0x0000FF))
 
@@ -77,6 +84,9 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Model' do
       expect(form.chassis[1].suspension.front).to eq model.chassis[1][:suspension].front
       expect(form.chassis[1].suspension.rear).to  eq model.chassis[1][:suspension].rear
       expect(form.chassis[1].brakes).to           eq model.chassis[1][:brakes]
+
+      expect(form.drivers_championships).to eq Array.new
+      expect(form.constructors_championships).to eq Array.new
 
       expect(form.colours).to be_a FormObj::ModelMapper::Array
       expect(form.colours.size).to eq 3
@@ -126,6 +136,13 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Model' do
           attribute :name
           attribute :rgb
         end
+        attribute :drivers_championships, array: true, model_attribute: false do
+          attribute :driver
+          attribute :year
+        end
+        attribute :constructors_championships, array: true, model_attribute: false do
+          attribute :year
+        end
       end
     end
 
@@ -174,6 +191,17 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Model' do
             attribute :name
             attribute :rgb
           end
+          class DriversChampionshipForm < FormObj::Form
+            include FormObj::ModelMapper
+
+            attribute :driver
+            attribute :year
+          end
+          class ConstructorsChampionshipForm < FormObj::Form
+            include FormObj::ModelMapper
+
+            attribute :year
+          end
           class TeamForm < FormObj::Form
             include FormObj::ModelMapper
 
@@ -183,6 +211,8 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Model' do
             attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm
             attribute :chassis, array: true, model_hash: true, class: ChassisForm
             attribute :colours, array: true, model_nesting: false, class: ColourForm
+            attribute :drivers_championships, array: true, class: DriversChampionshipForm, model_attribute: false
+            attribute :constructors_championships, array: true, class: ConstructorsChampionshipForm, model_attribute: false
           end
       end
     end

--- a/spec/model_mapper/load_from_models/array_of_forms_one_model_spec.rb
+++ b/spec/model_mapper/load_from_models/array_of_forms_one_model_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Model' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false do
+        attribute :colours, array: true, model_nesting: false do
           attribute :name
           attribute :rgb
         end
@@ -182,7 +182,7 @@ RSpec.describe 'load_from_model: Array of Form Objects - One Model' do
             attribute :cars, array: true, class: CarForm
             attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm
             attribute :chassis, array: true, model_hash: true, class: ChassisForm
-            attribute :colours, array: true, model_attribute: false, class: ColourForm
+            attribute :colours, array: true, model_nesting: false, class: ColourForm
           end
       end
     end

--- a/spec/model_mapper/load_from_models/nested_form_few_models_empty_spec.rb
+++ b/spec/model_mapper/load_from_models/nested_form_few_models_empty_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'load_from_models: Nested Form Objects - Few Empty Models' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false, model: :chassis do
+        attribute :chassis, model_nesting: false, model: :chassis do
           attribute :suspension do
             attribute :front
             attribute :rear
@@ -83,7 +83,7 @@ RSpec.describe 'load_from_models: Nested Form Objects - Few Empty Models' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false, model: :chassis
+          attribute :chassis, class: ChassisForm, model_nesting: false, model: :chassis
         end
       end
     end

--- a/spec/model_mapper/load_from_models/nested_form_few_models_spec.rb
+++ b/spec/model_mapper/load_from_models/nested_form_few_models_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'load_from_models: Nested Form Objects - Few Models' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false, model: :chassis do
+        attribute :chassis, model_nesting: false, model: :chassis do
           attribute :suspension do
             attribute :front
             attribute :rear
@@ -86,7 +86,7 @@ RSpec.describe 'load_from_models: Nested Form Objects - Few Models' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false, model: :chassis
+          attribute :chassis, class: ChassisForm, model_nesting: false, model: :chassis
         end
       end
     end

--- a/spec/model_mapper/load_from_models/nested_form_one_model_empty_spec.rb
+++ b/spec/model_mapper/load_from_models/nested_form_one_model_empty_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'load_from_model: Nested Form Objects - One Empty Model' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false do
+        attribute :chassis, model_nesting: false do
           attribute :suspension do
             attribute :front
             attribute :rear
@@ -84,7 +84,7 @@ RSpec.describe 'load_from_model: Nested Form Objects - One Empty Model' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false
+          attribute :chassis, class: ChassisForm, model_nesting: false
         end
       end
     end

--- a/spec/model_mapper/load_from_models/nested_form_one_model_spec.rb
+++ b/spec/model_mapper/load_from_models/nested_form_one_model_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'load_from_model: Nested Form Objects - One Model' do
             attribute :volume
           end
         end
-        attribute :chassis, model_attribute: false do
+        attribute :chassis, model_nesting: false do
           attribute :suspension do
             attribute :front
             attribute :rear
@@ -87,7 +87,7 @@ RSpec.describe 'load_from_model: Nested Form Objects - One Model' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false
+          attribute :chassis, class: ChassisForm, model_nesting: false
         end
       end
     end

--- a/spec/model_mapper/load_from_models/nested_form_one_model_spec.rb
+++ b/spec/model_mapper/load_from_models/nested_form_one_model_spec.rb
@@ -2,7 +2,9 @@ RSpec.describe 'load_from_model: Nested Form Objects - One Model' do
   let(:engine) { Struct.new(:power, :volume).new(335, 4.1) }
   let(:car) {{ code: '340 F1', driver: 'Ascari', engine: engine }}
   let(:suspension) { Struct.new(:front, :rear).new('independant', 'de Dion') }
-  let(:model) { Struct.new(:team_name, :year, :car, :suspension, :brakes).new('Ferrari', 1950, car, suspension, :drum) }
+  let(:drivers_championship) { Struct.new(:driver, :year).new('Ascari', 1952) }
+  let(:model) { Struct.new(:team_name, :year, :car, :suspension, :brakes, :drivers_championship).new('Ferrari', 1950, car, suspension, :drum, drivers_championship) }
+
   shared_examples 'a nested form' do
     it 'has all attributes correctly set up' do
       form.load_from_model(model)
@@ -48,6 +50,13 @@ RSpec.describe 'load_from_model: Nested Form Objects - One Model' do
           end
           attribute :brakes
         end
+        attribute :drivers_championship, model_attribute: false do
+          attribute :driver
+          attribute :year
+        end
+        attribute :constructors_championship, model_attribute: false do
+          attribute :year
+        end
       end
     end
 
@@ -81,6 +90,17 @@ RSpec.describe 'load_from_model: Nested Form Objects - One Model' do
           end
           attribute :brakes
         end
+        class DriversChampionshipForm < FormObj::Form
+          include FormObj::ModelMapper
+
+          attribute :driver
+          attribute :year
+        end
+        class ConstructorsChampionshipForm < FormObj::Form
+          include FormObj::ModelMapper
+
+          attribute :year
+        end
         class TeamForm < FormObj::Form
           include FormObj::ModelMapper
 
@@ -88,6 +108,8 @@ RSpec.describe 'load_from_model: Nested Form Objects - One Model' do
           attribute :car, class: CarForm, model_hash: true
           attribute :year
           attribute :chassis, class: ChassisForm, model_nesting: false
+          attribute :drivers_championship, class: DriversChampionshipForm, model_attribute: false
+          attribute :constructors_championship, class: ConstructorsChampionshipForm, model_attribute: false
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/array_of_forms_few_models_name_spec.rb
+++ b/spec/model_mapper/sync_to_models/array_of_forms_few_models_name_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'sync_to_models: Array of Form Objects - Few Models - Name' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false, model_class: 'SaveToModels::ArrayFormName::Colour', primary_key: :name do
+        attribute :colours, array: true, model_nesting: false, model_class: 'SaveToModels::ArrayFormName::Colour', primary_key: :name do
           attribute :name
           attribute :rgb
         end
@@ -285,7 +285,7 @@ RSpec.describe 'sync_to_models: Array of Form Objects - Few Models - Name' do
           attribute :cars, array: true, class: CarForm, model_class: 'SaveToModels::ArrayFormName::Car', primary_key: :code
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm, model_class: ['Hash', 'SaveToModels::ArrayFormName::Sponsor'], primary_key: :title
           attribute :chassis, array: true, model_hash: true, class: ChassisForm, model: :chassis
-          attribute :colours, array: true, model_attribute: false, class: ColourForm, model_class: 'SaveToModels::ArrayFormName::Colour', primary_key: :name
+          attribute :colours, array: true, model_nesting: false, class: ColourForm, model_class: 'SaveToModels::ArrayFormName::Colour', primary_key: :name
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/array_of_forms_few_models_spec.rb
+++ b/spec/model_mapper/sync_to_models/array_of_forms_few_models_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'sync_to_models: Array of Form Objects - Few Models' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false, model_class: Colour, primary_key: :name do
+        attribute :colours, array: true, model_nesting: false, model_class: Colour, primary_key: :name do
           attribute :name
           attribute :rgb
         end
@@ -285,7 +285,7 @@ RSpec.describe 'sync_to_models: Array of Form Objects - Few Models' do
           attribute :cars, array: true, class: CarForm, model_class: Car, primary_key: :code
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm, model_class: [Hash, Sponsor], primary_key: :title
           attribute :chassis, array: true, model_hash: true, class: ChassisForm, model: :chassis
-          attribute :colours, array: true, model_attribute: false, class: ColourForm, model_class: Colour, primary_key: :name
+          attribute :colours, array: true, model_nesting: false, class: ColourForm, model_class: Colour, primary_key: :name
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/array_of_forms_one_model_name_spec.rb
+++ b/spec/model_mapper/sync_to_models/array_of_forms_one_model_name_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model - Name' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false, model_class: 'SaveToModel::ArrayFormName::Colour', primary_key: :name do
+        attribute :colours, array: true, model_nesting: false, model_class: 'SaveToModel::ArrayFormName::Colour', primary_key: :name do
           attribute :name
           attribute :rgb
         end
@@ -283,7 +283,7 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model - Name' do
           attribute :cars, array: true, class: CarForm, model_class: 'SaveToModel::ArrayFormName::Car', primary_key: :code
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm, model_class: [Hash, 'SaveToModel::ArrayFormName::Sponsor'], primary_key: :title
           attribute :chassis, array: true, model_hash: true, class: ChassisForm
-          attribute :colours, array: true, model_attribute: false, class: ColourForm, model_class: 'SaveToModel::ArrayFormName::Colour', primary_key: :name
+          attribute :colours, array: true, model_nesting: false, class: ColourForm, model_class: 'SaveToModel::ArrayFormName::Colour', primary_key: :name
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/array_of_forms_one_model_spec.rb
+++ b/spec/model_mapper/sync_to_models/array_of_forms_one_model_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false, model_class: Colour, primary_key: :name do
+        attribute :colours, array: true, model_nesting: false, model_class: Colour, primary_key: :name do
           attribute :name
           attribute :rgb
         end
@@ -283,7 +283,7 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model' do
           attribute :cars, array: true, class: CarForm, model_class: Car, primary_key: :code
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm, model_class: [Hash, Sponsor], primary_key: :title
           attribute :chassis, array: true, model_hash: true, class: ChassisForm
-          attribute :colours, array: true, model_attribute: false, class: ColourForm, model_class: Colour, primary_key: :name
+          attribute :colours, array: true, model_nesting: false, class: ColourForm, model_class: Colour, primary_key: :name
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/array_of_forms_one_model_spec.rb
+++ b/spec/model_mapper/sync_to_models/array_of_forms_one_model_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model' do
       Colour = Struct.new(:name, :rgb, :secret)
 
       class Model < ::Array
-        attr_accessor :team_name, :year, :cars, :finance, :chassis
+        attr_accessor :team_name, :year, :cars, :finance, :chassis, :drivers_championships
       end
     end
   end
@@ -64,7 +64,23 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model' do
       colour.name = 'blue'
       colour.rgb = 0x0000FF
 
-      form.sync_to_model(model)
+      drivers_championship = form.drivers_championships.create
+      drivers_championship.driver = 'Ascari'
+      drivers_championship.year = 1952
+
+      drivers_championship = form.drivers_championships.create
+      drivers_championship.driver = 'Hawthorn'
+      drivers_championship.year = 1958
+
+      constructors_championship = form.constructors_championships.create
+      constructors_championship.year = 1961
+
+      constructors_championship = form.constructors_championships.create
+      constructors_championship.year = 1964
+
+      expect {
+        form.sync_to_model(model)
+      }.not_to raise_error
     end
   end
 
@@ -116,6 +132,8 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model' do
 
       expect(model[2].name).to eq 'blue'
       expect(model[2].rgb).to eq 0x0000FF
+
+      expect(model.drivers_championships).to be_nil
     end
 
     it 'returns self' do
@@ -153,6 +171,13 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model' do
         attribute :colours, array: true, model_nesting: false, model_class: Colour, primary_key: :name do
           attribute :name
           attribute :rgb
+        end
+        attribute :drivers_championships, array: true, model_attribute: false do
+          attribute :driver
+          attribute :year
+        end
+        attribute :constructors_championships, array: true, model_attribute: false do
+          attribute :year
         end
       end
     end
@@ -275,6 +300,17 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model' do
           attribute :name
           attribute :rgb
         end
+        class DriversChampionshipForm < FormObj::Form
+          include FormObj::ModelMapper
+
+          attribute :driver
+          attribute :year
+        end
+        class ConstructorsChampionshipForm < FormObj::Form
+          include FormObj::ModelMapper
+
+          attribute :year
+        end
         class TeamForm < FormObj::Form
           include FormObj::ModelMapper
 
@@ -284,6 +320,8 @@ RSpec.describe 'sync_to_model: Array of Form Objects - One Model' do
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm, model_class: [Hash, Sponsor], primary_key: :title
           attribute :chassis, array: true, model_hash: true, class: ChassisForm
           attribute :colours, array: true, model_nesting: false, class: ColourForm, model_class: Colour, primary_key: :name
+          attribute :drivers_championships, array: true, class: DriversChampionshipForm, model_attribute: false
+          attribute :constructors_championships, array: true, class: ConstructorsChampionshipForm, model_attribute: false
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/nested_form_few_models_name_spec.rb
+++ b/spec/model_mapper/sync_to_models/nested_form_few_models_name_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - Few Models - Name' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false, model: :chassis do
+        attribute :chassis, model_nesting: false, model: :chassis do
           attribute :suspension, model_class: 'SaveToModels::NestedFormName::Suspension' do
             attribute :front
             attribute :rear
@@ -129,7 +129,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - Few Models - Name' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false, model: :chassis
+          attribute :chassis, class: ChassisForm, model_nesting: false, model: :chassis
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/nested_form_few_models_spec.rb
+++ b/spec/model_mapper/sync_to_models/nested_form_few_models_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'sync_to_models: Nested Form Objects - Few Models' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false, model: :chassis do
+        attribute :chassis, model_nesting: false, model: :chassis do
           attribute :suspension, model_class: Suspension do
             attribute :front
             attribute :rear
@@ -129,7 +129,7 @@ RSpec.describe 'sync_to_models: Nested Form Objects - Few Models' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false, model: :chassis
+          attribute :chassis, class: ChassisForm, model_nesting: false, model: :chassis
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/nested_form_one_model_name_spec.rb
+++ b/spec/model_mapper/sync_to_models/nested_form_one_model_name_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model - Name' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false do
+        attribute :chassis, model_nesting: false do
           attribute :suspension, model_class: 'SaveToModel::NestedFormName::Suspension' do
             attribute :front
             attribute :rear
@@ -127,7 +127,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model - Name' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false
+          attribute :chassis, class: ChassisForm, model_nesting: false
         end
       end
     end

--- a/spec/model_mapper/sync_to_models/nested_form_one_model_spec.rb
+++ b/spec/model_mapper/sync_to_models/nested_form_one_model_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
 
   let(:engine) { SaveToModel::NestedForm::Engine.new }
   let(:suspension) { SaveToModel::NestedForm::Suspension.new }
-  let(:model) { Struct.new(:team_name, :year, :car, :suspension, :brakes).new }
+  let(:model) { Struct.new(:team_name, :year, :car, :suspension, :brakes, :drivers_championship).new }
 
   shared_context 'initialize form' do
     before do
@@ -23,6 +23,9 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
       form.chassis.suspension.front = 'independant'
       form.chassis.suspension.rear = 'de Dion'
       form.chassis.brakes = :drum
+      form.drivers_championship.driver = 'Ascari'
+      form.drivers_championship.year = 1952
+      form.constructors_championship.year = 1961
     end
   end
 
@@ -37,6 +40,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
       expect(model.suspension.front).to     eq form.chassis.suspension.front
       expect(model.suspension.rear).to      eq form.chassis.suspension.rear
       expect(model.brakes).to               eq form.chassis.brakes
+      expect(model.drivers_championship).to be_nil
     end
 
     it 'returns self' do
@@ -66,6 +70,13 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
           end
           attribute :brakes
         end
+        attribute :drivers_championship, model_attribute: false do
+          attribute :driver
+          attribute :year
+        end
+        attribute :constructors_championship, model_attribute: false do
+          attribute :year
+        end
       end
     end
 
@@ -73,7 +84,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
 
     context 'nested models are created when they do not exist yet' do
       include_context 'initialize form'
-      before { form.sync_to_model(model) }
+      before { expect { form.sync_to_model(model) }.not_to raise_error }
 
       it_behaves_like 'a form that can be saved'
     end
@@ -86,7 +97,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
       end
 
       include_context 'initialize form'
-      before { form.sync_to_model(model) }
+      before { expect { form.sync_to_model(model) }.not_to raise_error }
 
       it_behaves_like 'a form that can be saved'
 
@@ -124,6 +135,17 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
           end
           attribute :brakes
         end
+        class DriversChampionshipForm < FormObj::Form
+          include FormObj::ModelMapper
+
+          attribute :driver
+          attribute :year
+        end
+        class ConstructorsChampionshipForm < FormObj::Form
+          include FormObj::ModelMapper
+
+          attribute :year
+        end
         class TeamForm < FormObj::Form
           include FormObj::ModelMapper
 
@@ -131,6 +153,8 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
           attribute :car, class: CarForm, model_hash: true
           attribute :year
           attribute :chassis, class: ChassisForm, model_nesting: false
+          attribute :drivers_championship, class: DriversChampionshipForm, model_attribute: false
+          attribute :constructors_championship, class: ConstructorsChampionshipForm, model_attribute: false
         end
       end
     end
@@ -139,7 +163,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
 
     context 'nested models are created when they do not exist yet' do
       include_context 'initialize form'
-      before { form.sync_to_model(model) }
+      before { expect { form.sync_to_model(model) }.not_to raise_error }
 
       it_behaves_like 'a form that can be saved'
     end
@@ -152,7 +176,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
       end
 
       include_context 'initialize form'
-      before { form.sync_to_model(model) }
+      before { expect { form.sync_to_model(model) }.not_to raise_error }
 
       it_behaves_like 'a form that can be saved'
 

--- a/spec/model_mapper/sync_to_models/nested_form_one_model_spec.rb
+++ b/spec/model_mapper/sync_to_models/nested_form_one_model_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false do
+        attribute :chassis, model_nesting: false do
           attribute :suspension, model_class: Suspension do
             attribute :front
             attribute :rear
@@ -130,7 +130,7 @@ RSpec.describe 'sync_to_model: Nested Form Objects - One Model' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false
+          attribute :chassis, class: ChassisForm, model_nesting: false
         end
       end
     end

--- a/spec/model_mapper/to_model_hash/array_of_forms_few_models_spec.rb
+++ b/spec/model_mapper/to_model_hash/array_of_forms_few_models_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe 'to_models_hash: Array of Form Objects - Few Models' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false, primary_key: :name do
+        attribute :colours, array: true, model_nesting: false, primary_key: :name do
           attribute :name
           attribute :rgb
         end
@@ -208,7 +208,7 @@ RSpec.describe 'to_models_hash: Array of Form Objects - Few Models' do
           attribute :cars, array: true, class: CarForm, primary_key: :code
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm, primary_key: :title
           attribute :chassis, array: true, model_hash: true, class: ChassisForm, model: :chassis
-          attribute :colours, array: true, model_attribute: false, class: ColourForm, primary_key: :name
+          attribute :colours, array: true, model_nesting: false, class: ColourForm, primary_key: :name
         end
       end
     end

--- a/spec/model_mapper/to_model_hash/array_of_forms_one_model_spec.rb
+++ b/spec/model_mapper/to_model_hash/array_of_forms_one_model_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe 'to_model_hash: Array of Form Objects - One Model' do
       colour = form.colours.create
       colour.name = 'blue'
       colour.rgb = 0x0000FF
+
+      drivers_championship = form.drivers_championships.create
+      drivers_championship.driver = 'Ascari'
+      drivers_championship.year = 1952
+
+      drivers_championship = form.drivers_championships.create
+      drivers_championship.driver = 'Hawthorn'
+      drivers_championship.year = 1958
     end
   end
 
@@ -141,6 +149,10 @@ RSpec.describe 'to_model_hash: Array of Form Objects - One Model' do
           attribute :name
           attribute :rgb
         end
+        attribute :drivers_championships, array: true, model_attribute: false do
+          attribute :driver
+          attribute :year
+        end
       end
     end
 
@@ -191,6 +203,12 @@ RSpec.describe 'to_model_hash: Array of Form Objects - One Model' do
           attribute :name
           attribute :rgb
         end
+        class DriversChampionshipForm < FormObj::Form
+          include FormObj::ModelMapper
+
+          attribute :driver
+          attribute :year
+        end
         class TeamForm < FormObj::Form
           include FormObj::ModelMapper
 
@@ -200,6 +218,7 @@ RSpec.describe 'to_model_hash: Array of Form Objects - One Model' do
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm, primary_key: :title
           attribute :chassis, array: true, model_hash: true, class: ChassisForm
           attribute :colours, array: true, model_nesting: false, class: ColourForm, primary_key: :name
+          attribute :drivers_championships, array: true, class: DriversChampionshipForm, model_attribute: false
         end
       end
     end

--- a/spec/model_mapper/to_model_hash/array_of_forms_one_model_spec.rb
+++ b/spec/model_mapper/to_model_hash/array_of_forms_one_model_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe 'to_model_hash: Array of Form Objects - One Model' do
           end
           attribute :brakes
         end
-        attribute :colours, array: true, model_attribute: false, primary_key: :name do
+        attribute :colours, array: true, model_nesting: false, primary_key: :name do
           attribute :name
           attribute :rgb
         end
@@ -199,7 +199,7 @@ RSpec.describe 'to_model_hash: Array of Form Objects - One Model' do
           attribute :cars, array: true, class: CarForm, primary_key: :code
           attribute :sponsors, array: true, model_attribute: 'finance.:sponsors', class: SponsorForm, primary_key: :title
           attribute :chassis, array: true, model_hash: true, class: ChassisForm
-          attribute :colours, array: true, model_attribute: false, class: ColourForm, primary_key: :name
+          attribute :colours, array: true, model_nesting: false, class: ColourForm, primary_key: :name
         end
       end
     end

--- a/spec/model_mapper/to_model_hash/nested_form_few_models_spec.rb
+++ b/spec/model_mapper/to_model_hash/nested_form_few_models_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'to_models_hash: Nested Form Objects - Few Models' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false, model: :chassis do
+        attribute :chassis, model_nesting: false, model: :chassis do
           attribute :suspension do
             attribute :front
             attribute :rear
@@ -124,7 +124,7 @@ RSpec.describe 'to_models_hash: Nested Form Objects - Few Models' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false, model: :chassis
+          attribute :chassis, class: ChassisForm, model_nesting: false, model: :chassis
         end
       end
     end

--- a/spec/model_mapper/to_model_hash/nested_form_one_model_spec.rb
+++ b/spec/model_mapper/to_model_hash/nested_form_one_model_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'to_model_hash: Nested Form Objects - One Model' do
           end
           attribute :driver
         end
-        attribute :chassis, model_attribute: false do
+        attribute :chassis, model_nesting: false do
           attribute :suspension do
             attribute :front
             attribute :rear
@@ -99,7 +99,7 @@ RSpec.describe 'to_model_hash: Nested Form Objects - One Model' do
           attribute :name, model_attribute: :team_name
           attribute :car, class: CarForm, model_hash: true
           attribute :year
-          attribute :chassis, class: ChassisForm, model_attribute: false
+          attribute :chassis, class: ChassisForm, model_nesting: false
         end
       end
     end

--- a/spec/model_mapper/to_model_hash/nested_form_one_model_spec.rb
+++ b/spec/model_mapper/to_model_hash/nested_form_one_model_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe 'to_model_hash: Nested Form Objects - One Model' do
       form.chassis.suspension.front = 'independant'
       form.chassis.suspension.rear = 'de Dion'
       form.chassis.brakes = :drum
+      form.drivers_championship.driver = 'Ascari'
+      form.drivers_championship.year = 1952
     end
   end
 
@@ -59,6 +61,10 @@ RSpec.describe 'to_model_hash: Nested Form Objects - One Model' do
           end
           attribute :brakes
         end
+        attribute :drivers_championship, model_attribute: false do
+          attribute :driver
+          attribute :year
+        end
       end
     end
 
@@ -93,6 +99,12 @@ RSpec.describe 'to_model_hash: Nested Form Objects - One Model' do
           end
           attribute :brakes
         end
+        class DriversChampionshipForm < FormObj::Form
+          include FormObj::ModelMapper
+
+          attribute :driver
+          attribute :year
+        end
         class TeamForm < FormObj::Form
           include FormObj::ModelMapper
 
@@ -100,6 +112,7 @@ RSpec.describe 'to_model_hash: Nested Form Objects - One Model' do
           attribute :car, class: CarForm, model_hash: true
           attribute :year
           attribute :chassis, class: ChassisForm, model_nesting: false
+          attribute :drivers_championship, class: DriversChampionshipForm, model_attribute: false
         end
       end
     end


### PR DESCRIPTION
Close #7.

`model_attribute: false` disable mapping for the attribute
`model_nesting: false` disable model nesting while keeping corresponding form object nesting