### PR TITLE
Add load_from_model(s) as class methods

### DIFF
--- a/lib/form_obj/model_mapper.rb
+++ b/lib/form_obj/model_mapper.rb
@@ -27,6 +27,14 @@ module FormObj
       def model_primary_key
         ModelMapper::ModelPrimaryKey.new(_attributes.find(primary_key).model_attribute)
       end
+
+      def load_from_model(*args)
+        new.load_from_model(*args)
+      end
+
+      def load_from_models(*args)
+        new.load_from_models(*args)
+      end
     end
 
     def load_from_model(model, *args)

--- a/test/model_mapper/load_from_model_test.rb
+++ b/test/model_mapper/load_from_model_test.rb
@@ -64,7 +64,6 @@ class ModelMapperLoadFromModelTest < Minitest::Test
 
   def setup
     @team_model = TeamModel.new
-    @team = Team.new
   end
 
   def fill_in_model
@@ -150,16 +149,24 @@ class ModelMapperLoadFromModelTest < Minitest::Test
   end
 
   def test_that_load_from_model_returns_form_itself
+    @team = Team.new
     assert_same(@team, @team.load_from_model(@team_model))  
   end
 
   def test_that_all_attributes_value_are_correctly_loaded_from_empty_model_into_empty_form
+    @team = Team.new.load_from_model(@team_model)
+    check_that_all_attributes_value_are_correctly_loaded_from_empty_model
+    check_that_not_synced_attributes_are_still_empty
+
+    @team = Team.load_from_model(@team_model)
     check_that_all_attributes_value_are_correctly_loaded_from_empty_model
     check_that_not_synced_attributes_are_still_empty
   end
 
   def test_that_all_attributes_value_are_correctly_loaded_from_empty_model_into_filled_form
+    @team = Team.new
     fill_in_form
+    @team.load_from_model(@team_model)
 
     check_that_all_attributes_value_are_correctly_loaded_from_empty_model
     check_that_not_synced_attributes_keep_their_values
@@ -168,13 +175,21 @@ class ModelMapperLoadFromModelTest < Minitest::Test
   def test_that_all_attributes_value_are_correctly_loaded_from_filled_model_into_empty_form
     fill_in_model
 
+    @team = Team.new.load_from_model(@team_model)
+    check_that_all_attributes_value_are_correctly_loaded_from_filled_model
+    check_that_not_synced_attributes_are_still_empty
+
+    @team = Team.load_from_model(@team_model)
     check_that_all_attributes_value_are_correctly_loaded_from_filled_model
     check_that_not_synced_attributes_are_still_empty
   end
 
   def test_that_all_attributes_value_are_correctly_loaded_from_filled_model_into_filled_form
     fill_in_model
+
+    @team = Team.new
     fill_in_form
+    @team.load_from_model(@team_model)
 
     check_that_all_attributes_value_are_correctly_loaded_from_filled_model
     check_that_not_synced_attributes_keep_their_values
@@ -205,8 +220,6 @@ class ModelMapperLoadFromModelTest < Minitest::Test
   end
 
   def check_that_all_attributes_value_are_correctly_loaded_from_empty_model
-    @team.load_from_model(@team_model)
-
     assert_nil(@team.name)
     assert_nil(@team.year)
 
@@ -224,8 +237,6 @@ class ModelMapperLoadFromModelTest < Minitest::Test
   end
 
   def check_that_all_attributes_value_are_correctly_loaded_from_filled_model
-    @team.load_from_model(@team_model)
-
     assert_equal(@team_model.team_name, @team.name)
     assert_equal(@team_model.year, @team.year)
 

--- a/test/model_mapper/load_from_models_test.rb
+++ b/test/model_mapper/load_from_models_test.rb
@@ -66,8 +66,6 @@ class ModelMapperLoadFromModelsTest < Minitest::Test
   def setup
     @team_model = TeamModel.new
     @chassis_model = ChassisModel.new
-
-    @team = Team.new
   end
 
   def fill_in_models
@@ -154,16 +152,24 @@ class ModelMapperLoadFromModelsTest < Minitest::Test
   end
 
   def test_that_load_from_model_returns_form_itself
-    assert_same(@team, @team.load_from_model(@team_model))  
+    @team = Team.new
+    assert_same(@team, @team.load_from_model(@team_model))
   end
 
   def test_that_all_attributes_value_are_correctly_loaded_from_empty_models_into_empty_form
+    @team = Team.new.load_from_models(default: @team_model, chassis: @chassis_model)
+    check_that_all_attributes_value_are_correctly_loaded_from_empty_models
+    check_that_not_synched_attributes_are_still_empty
+
+    @team = Team.load_from_models(default: @team_model, chassis: @chassis_model)
     check_that_all_attributes_value_are_correctly_loaded_from_empty_models
     check_that_not_synched_attributes_are_still_empty
   end
 
   def test_that_all_attributes_value_are_correctly_loaded_from_empty_models_into_filled_form
+    @team = Team.new
     fill_in_form
+    @team.load_from_models(default: @team_model, chassis: @chassis_model)
 
     check_that_all_attributes_value_are_correctly_loaded_from_empty_models
     check_that_not_synched_attributes_keep_their_values
@@ -172,13 +178,21 @@ class ModelMapperLoadFromModelsTest < Minitest::Test
   def test_that_all_attributes_value_are_correctly_loaded_from_filled_models_into_empty_form
     fill_in_models
 
+    @team = Team.new.load_from_models(default: @team_model, chassis: @chassis_model)
+    check_that_all_attributes_value_are_correctly_loaded_from_filled_models
+    check_that_not_synched_attributes_are_still_empty
+
+    @team = Team.load_from_models(default: @team_model, chassis: @chassis_model)
     check_that_all_attributes_value_are_correctly_loaded_from_filled_models
     check_that_not_synched_attributes_are_still_empty
   end
 
   def test_that_all_attributes_value_are_correctly_loaded_from_filled_models_into_filled_form
     fill_in_models
+
+    @team = Team.new
     fill_in_form
+    @team.load_from_models(default: @team_model, chassis: @chassis_model)
 
     check_that_all_attributes_value_are_correctly_loaded_from_filled_models
     check_that_not_synched_attributes_keep_their_values
@@ -209,8 +223,6 @@ class ModelMapperLoadFromModelsTest < Minitest::Test
   end
 
   def check_that_all_attributes_value_are_correctly_loaded_from_empty_models
-    @team.load_from_models(default: @team_model, chassis: @chassis_model)
-
     assert_nil(@team.name)
     assert_nil(@team.year)
 
@@ -228,8 +240,6 @@ class ModelMapperLoadFromModelsTest < Minitest::Test
   end
 
   def check_that_all_attributes_value_are_correctly_loaded_from_filled_models
-    @team.load_from_models(default: @team_model, chassis: @chassis_model)
-
     assert_equal(@team_model.team_name, @team.name)
     assert_equal(@team_model.year, @team.year)
 


### PR DESCRIPTION
Allow to create a new instance of `FormObj::Form` class with included `FormObj::ModelMapper` by simple call on class method load_from_model(s)