### PR TITLE
Bugfix assigning subform

### DIFF
--- a/lib/form_obj/struct.rb
+++ b/lib/form_obj/struct.rb
@@ -80,7 +80,7 @@ module FormObj
         if attr.nil?
           raise UnknownAttributeError.new(attr_name) if raise_if_not_found
         else
-          if attr.subform?
+          if attr.subform? && !attr_value.is_a?(FormObj::Struct)
             read_attribute(attr).update_attributes(attr_value, raise_if_not_found: raise_if_not_found)
           else
             update_attribute(attr, attr_value)

--- a/test/form/initialize_attributes_test.rb
+++ b/test/form/initialize_attributes_test.rb
@@ -29,6 +29,7 @@ class FormInitializeAttributesTest < Minitest::Test
   end
 
   def test_that_all_attributes_are_correctly_initialized
+    suspension = Suspension.new(front: 'independent', rear: 'de Dion')
     team = Team.new(
         name: 'McLaren',
         'name' => 'Ferrari',
@@ -41,10 +42,7 @@ class FormInitializeAttributesTest < Minitest::Test
                        volume: 4.1
                    },
                    chassis: {
-                       suspension: {
-                           front: 'independent',
-                           rear: 'de Dion',
-                       },
+                       suspension: suspension,
                        brakes: :drum,
                    }
                }, {

--- a/test/model_mapper/inherited_from_form/initialize_attributes_test.rb
+++ b/test/model_mapper/inherited_from_form/initialize_attributes_test.rb
@@ -37,6 +37,7 @@ class ModelMapperInitializeAttributesTest < Minitest::Test
   end
 
   def test_that_all_attributes_are_correctly_initialized
+    suspension = Suspension.new(front: 'independent', rear: 'de Dion')
     team = Team.new(
         name: 'McLaren',
         'name' => 'Ferrari',
@@ -49,10 +50,7 @@ class ModelMapperInitializeAttributesTest < Minitest::Test
                        volume: 4.1
                    },
                    chassis: {
-                       suspension: {
-                           front: 'independent',
-                           rear: 'de Dion',
-                       },
+                       suspension: suspension,
                        brakes: :drum,
                    }
                }, {

--- a/test/struct/initialize_attributes_test.rb
+++ b/test/struct/initialize_attributes_test.rb
@@ -13,6 +13,9 @@ class StructInitializeAttributesTest < Minitest::Test
     attribute :name
     attribute :rgb
   end
+  class Sponsor < FormObj::Form
+    attribute :name
+  end
   class Team < FormObj::Struct
     attribute :name
     attribute :year
@@ -29,6 +32,7 @@ class StructInitializeAttributesTest < Minitest::Test
   end
 
   def test_that_all_attributes_are_correctly_initialized
+    suspension = Suspension.new(front: 'independent', rear: 'de Dion')
     team = Team.new(
         name: 'McLaren',
         'name' => 'Ferrari',
@@ -41,10 +45,7 @@ class StructInitializeAttributesTest < Minitest::Test
                        volume: 4.1
                    },
                    chassis: {
-                       suspension: {
-                           front: 'independent',
-                           rear: 'de Dion',
-                       },
+                       suspension: suspension,
                        brakes: :drum,
                    }
                }, {
@@ -71,7 +72,7 @@ class StructInitializeAttributesTest < Minitest::Test
                       name: :white,
                       'rgb' => nil,
                       rgb: 0xFFFFFF,
-                  }]
+                  }],
     )
 
     assert_equal('Ferrari', team.name)


### PR DESCRIPTION
Assigning subform to a subform attribute was not working. In old Rails the error was raised. In new Rails the new form with the same values was created